### PR TITLE
Loose package weight by excluding some files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+.github export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+.travis.yml export-ignore
+.scrutinizer.yml export-ignore
+phpunit.xml.dist export-ignore
+tests export-ignore


### PR DESCRIPTION
Hi,

Lets not publish all those file.
`.gitattributes` can be used to exclude files from final archive that is downloaded by composer.


Read more
- https://madewithlove.be/gitattributes/
- https://alexbilbie.com/2012/11/exclude-objects-with-gitattributes/
- http://www.pixelite.co.nz/article/using-git-attributes-exclude-files-your-release/